### PR TITLE
Refine redundant modelling

### DIFF
--- a/src/game/GameArena/Visualizer.tsx
+++ b/src/game/GameArena/Visualizer.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import ReactPlayer from 'react-player';
 import { makeStyles, createStyles, Box, Chip, Grid, Paper, Typography } from '@material-ui/core';
 import { useKeyPressEvent } from 'react-use';
-import { Song, Comment } from '../gameModels';
-import useGameEngine from './useGameEngine';
+import { Song } from '../gameModels';
+import useGameEngine, { getCurrentHit } from './useGameEngine';
 import { useHistory } from 'react-router';
 
 const useStyles = makeStyles((theme) =>
@@ -56,10 +56,12 @@ const Visualizer: React.FC<VisualizerProps> = ({ song }) => {
   const [colorIdx, setColorIdx] = useState(0);
   const [progress, setProgress] = useState(0);
   const [duration, setDuration] = useState(0);
-  const [{ accumulatedScore: score, comment }, dispatch] = useGameEngine();
+  const [gameState, dispatch] = useGameEngine();
   const history = useHistory();
   const classes = useStyles();
 
+  const currentHit = getCurrentHit(gameState);
+  const score = gameState.accumulatedScore;
   const timeLeft = secondsToMinutes(duration - progress);
 
   useKeyPressEvent(isSpace, () => {
@@ -129,21 +131,21 @@ const Visualizer: React.FC<VisualizerProps> = ({ song }) => {
           </Paper>
           <Paper variant="outlined" className={classes.progressInfo}>
             <Typography variant="subtitle2">COMMENTS</Typography>
-            {comment === Comment.TooEarly && (
+            {currentHit?.type === 'TooEarly' && (
               <Box color="error.main">
                 <Typography variant="h5">
                   <strong>Too early!</strong>
                 </Typography>
               </Box>
             )}
-            {comment === Comment.Excellent && (
+            {currentHit?.type === 'Excellent' && (
               <Box color="success.main">
                 <Typography variant="h5">
                   <strong>Excellent!!</strong>
                 </Typography>
               </Box>
             )}
-            {comment === Comment.Good && (
+            {currentHit?.type === 'Good' && (
               <Box color="info.main">
                 <Typography variant="h5">
                   <strong>Good!</strong>

--- a/src/game/GameArena/useGameEngine.test.ts
+++ b/src/game/GameArena/useGameEngine.test.ts
@@ -1,9 +1,11 @@
-import { reducer as gameEngineReducer } from './useGameEngine';
-import { Comment } from '../gameModels';
+import { reducer as gameEngineReducer, getCurrentHit } from './useGameEngine';
+import { tooEarly, excellent, good, miss } from '../gameModels';
 
 test('stores time information on beat', () => {
   const finalState = gameEngineReducer(undefined!, { type: 'RECORD_BEAT', payload: 1 });
+
   expect(finalState.currentBeatTime).toEqual(1);
+  expect(getCurrentHit(finalState)).toBeUndefined();
 });
 
 test('detects too early space hit within a beat interval', () => {
@@ -11,26 +13,26 @@ test('detects too early space hit within a beat interval', () => {
   const state2 = gameEngineReducer(state1, { type: 'CALCULATE_SCORE', payload: 2 });
   const finalState = gameEngineReducer(state2, { type: 'CALCULATE_SCORE', payload: 3 });
 
-  expect(finalState.comment).toEqual(Comment.TooEarly);
+  expect(getCurrentHit(finalState)).toEqual(tooEarly());
 });
 
 test('produces excellent point when user hits space within < 80ms after beat', () => {
   const state1 = gameEngineReducer(undefined!, { type: 'RECORD_BEAT', payload: 100 });
   const finalState = gameEngineReducer(state1, { type: 'CALCULATE_SCORE', payload: 160 });
 
-  expect(finalState.comment).toEqual(Comment.Excellent);
+  expect(getCurrentHit(finalState)).toEqual(excellent());
 });
 
 test('produces good point when user hits space within 81-120ms after beat', () => {
   const state1 = gameEngineReducer(undefined!, { type: 'RECORD_BEAT', payload: 100 });
   const finalState = gameEngineReducer(state1, { type: 'CALCULATE_SCORE', payload: 210 });
 
-  expect(finalState.comment).toEqual(Comment.Good);
+  expect(getCurrentHit(finalState)).toEqual(good());
 });
 
 test('produces no point when user hits space within >120ms after beat', () => {
   const state1 = gameEngineReducer(undefined!, { type: 'RECORD_BEAT', payload: 100 });
   const finalState = gameEngineReducer(state1, { type: 'CALCULATE_SCORE', payload: 250 });
 
-  expect(finalState.comment).toEqual(Comment.NoComment);
+  expect(getCurrentHit(finalState)).toEqual(miss());
 });

--- a/src/game/GameArena/useGameEngine.ts
+++ b/src/game/GameArena/useGameEngine.ts
@@ -1,15 +1,13 @@
-import { calculateHitPoint, feedbackMessage, Comment } from '../gameModels';
+import { calculateHitPoint, HitPoint, tooEarly } from '../gameModels';
 import { Reducer, useReducer } from 'react';
 
 type Milliseconds = number;
 type BeatTime = Milliseconds;
-type HitTime = Milliseconds;
 
 type State = {
   accumulatedScore: number;
   currentBeatTime: BeatTime;
-  hitHistory: [BeatTime, HitTime][];
-  comment: Comment;
+  hitHistory: [BeatTime, HitPoint][];
 };
 
 type Actions =
@@ -20,7 +18,6 @@ const initialState: State = {
   accumulatedScore: 0,
   currentBeatTime: 0,
   hitHistory: [],
-  comment: Comment.NoComment,
 };
 
 export const reducer: Reducer<State, Actions> = (state = initialState, action) => {
@@ -36,27 +33,23 @@ export const reducer: Reducer<State, Actions> = (state = initialState, action) =
       const now = action.payload;
       const diff = now - currentBeatTime;
 
-      const nextHitHistory = state.hitHistory.concat([[currentBeatTime, now]]);
-
       // Inspect the beat-time the last time you hit the space, if it's the same as the current beat-time,
-      // means you're hitting space more than once within the beat interval. In that case, show
-      // "Too early" message
-      const lastSpaceHit = hitHistory[hitHistory.length - 1];
-      const hitSpaceTooFast = lastSpaceHit !== undefined && lastSpaceHit[0] === currentBeatTime;
-      if (hitSpaceTooFast) {
+      // means you're hitting space more than once within the beat interval. In that case, you are
+      // considered hitting space too early
+      const [lastBeatTime] = hitHistory[hitHistory.length - 1] || [];
+      const hitSpaceTooEarly = lastBeatTime === currentBeatTime;
+      if (hitSpaceTooEarly) {
         return {
           ...state,
-          comment: Comment.TooEarly,
-          hitHistory: nextHitHistory,
+          hitHistory: state.hitHistory.concat([[currentBeatTime, tooEarly()]]),
         };
       }
 
-      const currPoint = calculateHitPoint(diff);
+      const currentHit = calculateHitPoint(diff);
       return {
         ...state,
-        hitHistory: nextHitHistory,
-        accumulatedScore: state.accumulatedScore + currPoint.point,
-        comment: feedbackMessage(currPoint),
+        hitHistory: state.hitHistory.concat([[currentBeatTime, currentHit]]),
+        accumulatedScore: state.accumulatedScore + currentHit.point,
       };
     }
     default:
@@ -64,8 +57,17 @@ export const reducer: Reducer<State, Actions> = (state = initialState, action) =
   }
 };
 
-const useGameEngine = () => {
-  return useReducer(reducer, initialState);
+const useGameEngine = () => useReducer(reducer, initialState);
+
+/**
+ * A selector function to get the current hit from state. Technically it's just
+ * the last item of `hitHistory`
+ */
+export const getCurrentHit = (state: State): HitPoint | undefined => {
+  const { hitHistory } = state;
+  const [, currentHit] = hitHistory[hitHistory.length - 1] || [];
+
+  return currentHit;
 };
 
 export default useGameEngine;

--- a/src/game/gameModels.ts
+++ b/src/game/gameModels.ts
@@ -20,11 +20,13 @@ export type Leaderboard = PlayerRecord[];
 export type HitPoint =
   | { type: 'Excellent'; point: 10 }
   | { type: 'Good'; point: 5 }
-  | { type: 'Miss'; point: 0 };
+  | { type: 'Miss'; point: 0 }
+  | { type: 'TooEarly'; point: 0 };
 
 export const excellent = (): HitPoint => ({ type: 'Excellent', point: 10 });
 export const good = (): HitPoint => ({ type: 'Good', point: 5 });
 export const miss = (): HitPoint => ({ type: 'Miss', point: 0 });
+export const tooEarly = (): HitPoint => ({ type: 'TooEarly', point: 0 });
 
 const isExcellent = (diff: number) => diff <= 80;
 const isGood = (diff: number) => 81 <= diff && diff <= 120;
@@ -33,22 +35,4 @@ export const calculateHitPoint = (diff: number) => {
   if (isExcellent(diff)) return excellent();
   if (isGood(diff)) return good();
   return miss();
-};
-
-export enum Comment {
-  NoComment,
-  TooEarly,
-  Excellent,
-  Good,
-}
-
-export const feedbackMessage = (hitPoint: HitPoint) => {
-  switch (hitPoint.type) {
-    case 'Excellent':
-      return Comment.Excellent;
-    case 'Good':
-      return Comment.Good;
-    default:
-      return Comment.NoComment;
-  }
 };


### PR DESCRIPTION
This MR is quite interesting as I found a number of redundancy in the current modelling:

- Remove `comment` from state as it can be just derived/calculated plainly from a hit point. This is to achieve one source of truth. General rule of thumb: store states as few as possible, AND they should be the source of truth.
- Add `TooEarly` variant to `HitPoint` type. It was previously part of comment. But actually it suits more to `HitPoint` as it's still related to timing concept. (It's not part of the assignment requirements tho)
- Modify `hitHistory` to include hit point. As a consequence, I also introduce `getCurrentHit` selector.

TODO:
- Might want to extract `accumulatedScore` from the state. It can be calculated
  - either by summing `hitHistory`,
  - or by accumulating it in the component